### PR TITLE
fix `wasm_runtime_layer` at `0.4.x`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ ref-cast = { version = "1.0.23", default-features = false }
 semver = { version = "1.0.23", default-features = false }
 serde = { version = "1.0.204", optional = true, default-features = false, features = [ "derive", "rc" ] }
 slab = { version = "0.4.9", default-features = false }
-wasm_runtime_layer = { version = ">=0.4.0", default-features = false }
 wasmtime-environ = { version = "18.0.1", features = [ "component-model" ] }
+wasm_runtime_layer = { version = "0.4", default-features = false }
 wit-component = { version = "0.19.0", default-features = false }
 wit-parser = { version = "0.13.0", default-features = false }
 


### PR DESCRIPTION
Required since `wasm_runtime_layer` version `0.5.0` breaks `v0.1.18`

fixes #25