### PR TITLE
Update to `wasm_runtime_layer` v0.6 (breaking)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ wasmtime-environ = { version = "18.0.1", features = [ "component-model" ] }
 wit-component = { version = "0.19.0", default-features = false }
 wit-parser = { version = "0.13.0", default-features = false }
 
+[patch.crates-io]
+wasm_runtime_layer = { git = "https://github.com/DouglasDwyer/wasm_runtime_layer", rev = "efbea9e92e82d6fd3e97af9386e5f7517c64db12" }
+
 [features]
 serde = [ "dep:serde", "semver/serde" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm_component_layer"
-version = "0.1.18"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/DouglasDwyer/wasm_component_layer"
@@ -18,7 +18,7 @@ ref-cast = { version = "1.0.23", default-features = false }
 semver = { version = "1.0.23", default-features = false }
 serde = { version = "1.0.204", optional = true, default-features = false, features = [ "derive", "rc" ] }
 slab = { version = "0.4.9", default-features = false }
-wasm_runtime_layer = { version = ">=0.4.0", default-features = false }
+wasm_runtime_layer = { version = "0.6.0", default-features = false }
 wasmtime-environ = { version = "18.0.1", features = [ "component-model" ] }
 wit-component = { version = "0.19.0", default-features = false }
 wit-parser = { version = "0.13.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,5 @@ wit-parser = { version = "0.13.0", default-features = false }
 serde = [ "dep:serde", "semver/serde" ]
 
 [dev-dependencies]
-wasmi = "0.31.1"
-wasmi_runtime_layer = "0.31.0"
+wasmi = "0.48.0"
+wasmi_runtime_layer = "0.48.0"

--- a/src/func.rs
+++ b/src/func.rs
@@ -1395,7 +1395,7 @@ type FunctionBacking<T, E> =
 type FunctionBackingKeyPair<T, E> = (Arc<AtomicUsize>, Arc<FunctionBacking<T, E>>);
 
 /// A vector for functions that automatically drops items when the references are dropped.
-pub(crate) struct FuncVec<T, E: backend::WasmEngine> {
+pub(crate) struct FuncVec<T: 'static, E: backend::WasmEngine> {
     /// The functions stored in the vector.
     functions: Vec<FunctionBackingKeyPair<T, E>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ impl Component {
             modules.insert(
                 id,
                 ModuleTranslation {
-                    module: Module::new(engine, std::io::Cursor::new(module.wasm))?,
+                    module: Module::new(engine, module.wasm)?,
                     translation: module.module,
                 },
             );
@@ -1966,7 +1966,7 @@ struct ComponentExport {
 /// the Wasm bytes into a valid module artifact).
 ///
 /// Spec: <https://webassembly.github.io/spec/core/exec/runtime.html#store>
-pub struct Store<T, E: backend::WasmEngine> {
+pub struct Store<T: 'static, E: backend::WasmEngine> {
     /// The backing implementation.
     inner: wasm_runtime_layer::Store<StoreInner<T, E>, E>,
 }
@@ -2030,7 +2030,7 @@ impl<T, E: backend::WasmEngine> Store<T, E> {
 ///
 /// This type is suitable for [`AsContext`] trait bounds on methods if desired.
 /// For more information, see [`Store`].
-pub struct StoreContext<'a, T: 'a, E: backend::WasmEngine> {
+pub struct StoreContext<'a, T: 'static, E: backend::WasmEngine> {
     /// The backing implementation.
     inner: wasm_runtime_layer::StoreContext<'a, StoreInner<T, E>, E>,
 }
@@ -2053,7 +2053,7 @@ impl<'a, T: 'a, E: backend::WasmEngine> StoreContext<'a, T, E> {
 ///
 /// This type is suitable for [`AsContextMut`] or [`AsContext`] trait bounds on methods if desired.
 /// For more information, see [`Store`].
-pub struct StoreContextMut<'a, T: 'a, E: backend::WasmEngine> {
+pub struct StoreContextMut<'a, T: 'static, E: backend::WasmEngine> {
     /// The backing implementation.
     inner: wasm_runtime_layer::StoreContextMut<'a, StoreInner<T, E>, E>,
 }
@@ -2085,7 +2085,7 @@ pub trait AsContext {
     type Engine: backend::WasmEngine;
 
     /// The user state associated with the [`Store`], aka the `T` in `Store<T>`.
-    type UserState;
+    type UserState: 'static;
 
     /// Returns the store context that this type provides access to.
     fn as_context(&self) -> StoreContext<Self::UserState, Self::Engine>;
@@ -2176,7 +2176,7 @@ impl<'a, T: 'a, E: backend::WasmEngine> AsContextMut for StoreContextMut<'a, T, 
 }
 
 /// Holds the inner mutable state for a component model implementation.
-struct StoreInner<T, E: backend::WasmEngine> {
+struct StoreInner<T: 'static, E: backend::WasmEngine> {
     /// The unique ID of this store.
     pub id: u64,
     /// The consumer's custom data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2088,13 +2088,13 @@ pub trait AsContext {
     type UserState: 'static;
 
     /// Returns the store context that this type provides access to.
-    fn as_context(&self) -> StoreContext<Self::UserState, Self::Engine>;
+    fn as_context(&self) -> StoreContext<'_, Self::UserState, Self::Engine>;
 }
 
 /// A trait used to get exclusive access to a [`Store`].
 pub trait AsContextMut: AsContext {
     /// Returns the store context that this type provides access to.
-    fn as_context_mut(&mut self) -> StoreContextMut<Self::UserState, Self::Engine>;
+    fn as_context_mut(&mut self) -> StoreContextMut<'_, Self::UserState, Self::Engine>;
 }
 
 impl<T, E: backend::WasmEngine> AsContext for Store<T, E> {
@@ -2102,7 +2102,7 @@ impl<T, E: backend::WasmEngine> AsContext for Store<T, E> {
 
     type UserState = T;
 
-    fn as_context(&self) -> StoreContext<Self::UserState, Self::Engine> {
+    fn as_context(&self) -> StoreContext<'_, Self::UserState, Self::Engine> {
         StoreContext {
             inner: wasm_runtime_layer::AsContext::as_context(&self.inner),
         }
@@ -2110,7 +2110,7 @@ impl<T, E: backend::WasmEngine> AsContext for Store<T, E> {
 }
 
 impl<T, E: backend::WasmEngine> AsContextMut for Store<T, E> {
-    fn as_context_mut(&mut self) -> StoreContextMut<Self::UserState, Self::Engine> {
+    fn as_context_mut(&mut self) -> StoreContextMut<'_, Self::UserState, Self::Engine> {
         StoreContextMut {
             inner: wasm_runtime_layer::AsContextMut::as_context_mut(&mut self.inner),
         }
@@ -2122,7 +2122,7 @@ impl<T: AsContext> AsContext for &T {
 
     type UserState = T::UserState;
 
-    fn as_context(&self) -> StoreContext<Self::UserState, Self::Engine> {
+    fn as_context(&self) -> StoreContext<'_, Self::UserState, Self::Engine> {
         (**self).as_context()
     }
 }
@@ -2132,13 +2132,13 @@ impl<T: AsContext> AsContext for &mut T {
 
     type UserState = T::UserState;
 
-    fn as_context(&self) -> StoreContext<Self::UserState, Self::Engine> {
+    fn as_context(&self) -> StoreContext<'_, Self::UserState, Self::Engine> {
         (**self).as_context()
     }
 }
 
 impl<T: AsContextMut> AsContextMut for &mut T {
-    fn as_context_mut(&mut self) -> StoreContextMut<Self::UserState, Self::Engine> {
+    fn as_context_mut(&mut self) -> StoreContextMut<'_, Self::UserState, Self::Engine> {
         (**self).as_context_mut()
     }
 }
@@ -2148,7 +2148,7 @@ impl<'a, T: 'a, E: backend::WasmEngine> AsContext for StoreContext<'a, T, E> {
 
     type UserState = T;
 
-    fn as_context(&self) -> StoreContext<Self::UserState, Self::Engine> {
+    fn as_context(&self) -> StoreContext<'_, Self::UserState, Self::Engine> {
         StoreContext {
             inner: wasm_runtime_layer::AsContext::as_context(&self.inner),
         }
@@ -2160,7 +2160,7 @@ impl<'a, T: 'a, E: backend::WasmEngine> AsContext for StoreContextMut<'a, T, E> 
 
     type UserState = T;
 
-    fn as_context(&self) -> StoreContext<Self::UserState, Self::Engine> {
+    fn as_context(&self) -> StoreContext<'_, Self::UserState, Self::Engine> {
         StoreContext {
             inner: wasm_runtime_layer::AsContext::as_context(&self.inner),
         }
@@ -2168,7 +2168,7 @@ impl<'a, T: 'a, E: backend::WasmEngine> AsContext for StoreContextMut<'a, T, E> 
 }
 
 impl<'a, T: 'a, E: backend::WasmEngine> AsContextMut for StoreContextMut<'a, T, E> {
-    fn as_context_mut(&mut self) -> StoreContextMut<Self::UserState, Self::Engine> {
+    fn as_context_mut(&mut self) -> StoreContextMut<'_, Self::UserState, Self::Engine> {
         StoreContextMut {
             inner: wasm_runtime_layer::AsContextMut::as_context_mut(&mut self.inner),
         }


### PR DESCRIPTION
I added some new `'static` bounds to match `wasm_runtime_layer`, which is obviously a breaking change, so I also increased the version to `0.2.0`.

Also, I removed the `>=` from the `wasm_runtime_layer` dependency, since we already saw what happened due to that (#25).

Also also: Apparently the version 0.6 of `wasm_runtime_layer` on crates.io is broken, so I patched it to the current main in the `Cargo.toml`. This means that this PR is blocked on the next version of `wasm_runtime_layer` being released, whereafter that patch can be removed.